### PR TITLE
Add the interface ErrorInterface

### DIFF
--- a/errs/errors.go
+++ b/errs/errors.go
@@ -8,6 +8,23 @@ import (
 	"strings"
 )
 
+var (
+	_ ErrorInterface = &Error{}
+)
+
+// ErrorInterface is the interface Error implements, using this interface
+// allows Error to be wrapped.
+type ErrorInterface interface {
+	Count() int
+	Message() string
+	Error() string
+	Detail(trimRuntime bool) string
+	StackTrace(trimRuntime bool) string
+	ErrorOrNil() error
+	WrappedErrors() []error
+	Format(state fmt.State, verb rune)
+}
+
 // Error holds the detailed error message.
 type Error struct {
 	errors []detail

--- a/errs/errors.go
+++ b/errs/errors.go
@@ -9,20 +9,23 @@ import (
 )
 
 var (
-	_ ErrorInterface = &Error{}
+	_ ErrorWrapper = &Error{}
+	_ StackError   = &Error{}
 )
 
-// ErrorInterface is the interface Error implements, using this interface
-// allows Error to be wrapped.
-type ErrorInterface interface {
+// ErrorWrapper contains methods for interacting with the wrapped errors.
+type ErrorWrapper interface {
+	error
 	Count() int
+	WrappedErrors() []error
+}
+
+// StackError contains methods with the stack trace and message.
+type StackError interface {
+	error
 	Message() string
-	Error() string
 	Detail(trimRuntime bool) string
 	StackTrace(trimRuntime bool) string
-	ErrorOrNil() error
-	WrappedErrors() []error
-	Format(state fmt.State, verb rune)
 }
 
 // Error holds the detailed error message.


### PR DESCRIPTION
This will allow other errors that implement the same methods (ie, duck
typing) to reap the benefits of Error.