### PR TITLE
Remove tnx.nl/ip

### DIFF
--- a/xio/network/external_ip.go
+++ b/xio/network/external_ip.go
@@ -30,7 +30,6 @@ var sites = []string{
 	"http://checkip.amazonaws.com/",
 	"http://ident.me/",
 	"https://canihazip.com/s",
-	"https://tnx.nl/ip",
 }
 
 // ExternalIP returns your IP address as seen by external sites. It does this by iterating through a list of websites


### PR DESCRIPTION
The service at http://tnx.nl/ip has been discontinued for a while, but still gets ~180 requests per second on average. Please remove it from this project and other projects you may have used it in.